### PR TITLE
add global git config entry for GITHUB_WORKSPACE as a safe.directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ if [[ "$INPUT_ALLOW_FF" == "true" ]]; then
   fi
 fi
 
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
 git remote set-url origin https://x-access-token:${!INPUT_PUSH_TOKEN}@github.com/$GITHUB_REPOSITORY.git
 git config --global user.name "$INPUT_USER_NAME"
 git config --global user.email "$INPUT_USER_EMAIL"


### PR DESCRIPTION
# Purpose
Supply git configuration to allow the GITHUB_WORKSPACE to be considered a 'safe directory' by git.

# Implementation
* Tell git that that directory is a safe one.
* Approach suggested by actions/checkout#766 and imitated from @JavidPack's comment in #11 

(if you'd prefer to do the PR @JavidPack, say the word)